### PR TITLE
Pull in metaExtra before generating titles

### DIFF
--- a/lib/metalsmith-plugins.coffee
+++ b/lib/metalsmith-plugins.coffee
@@ -25,11 +25,12 @@ module.exports = (config, navTree) ->
 
   exports.populateFileMeta = walkFiles (file, files) ->
     obj = files[file]
+    _.assign(obj, getValue(config.metaExtra, file, obj))
     title = obj.title or extractTitleFromText(obj.contents.toString())
     obj.title = HbHelper.render(title, obj)
     [ obj.ref, obj.ext ] = filenameToRef(file)
     fileByRef[obj.ref] = obj
-    _.assign(obj, getValue(config.metaExtra, file, obj))
+    
 
   exports.buildSearchIndex = ->
     console.log('Building search index...')


### PR DESCRIPTION
Previously, the metaExtra information was pulled in as the last piece of populateFileMeta. This pulls it in before the titles are generated so that variables defined in metaExtra can be used to populate titles.

Change-type: patch