### PR TITLE
Add support for subpaths

### DIFF
--- a/lib/build.coffee
+++ b/lib/build.coffee
@@ -10,6 +10,7 @@ permalinks = require('metalsmith-permalinks')
 layouts = require('metalsmith-layouts')
 inplace = require('metalsmith-in-place')
 headings = require('metalsmith-headings')
+prefixoid = require('metalsmith-prefixoid')
 Plugins = require('./metalsmith-plugins')
 
 { defaultPartialsSearch } = require('@resin.io/doxx-utils')
@@ -18,6 +19,7 @@ HbHelper = require('@resin.io/doxx-handlebars-helper')
 require('handlebars-helpers')({
   handlebars: HbHelper.Handlebars
 })
+
 require('./extra-handlebars-helpers')({
   handlebars: HbHelper.Handlebars
 })
@@ -86,6 +88,28 @@ module.exports = (cb) ->
     default: config.defaultTemplate
     locals: this.getLocals({ nav: navTree })
   })
+
+  if config.pathPrefix
+    use(true, prefixoid, {
+      prefix: config.pathPrefix
+    })
+
+    use(true, prefixoid, {
+      prefix: config.pathPrefix
+      tag: 'img'
+      attr: 'src'
+    })
+
+    use(true, prefixoid, {
+      prefix: config.pathPrefix
+      tag: 'script'
+      attr: 'src'
+    })
+
+    use(true, prefixoid, {
+      prefix: config.pathPrefix
+      tag: 'link'
+    })
 
   metalsmith.build (err) ->
     return cb(err) if err

--- a/lib/metalsmith-plugins.coffee
+++ b/lib/metalsmith-plugins.coffee
@@ -12,7 +12,6 @@ Dicts = require('./dictionaries')
 { extractTitleFromText, slugify, replacePlaceholders,
   filenameToRef, refToFilename, getValue } = require('./util')
 
-
 module.exports = (config, navTree) ->
   dicts = Dicts(config)
   exports = {}
@@ -30,7 +29,6 @@ module.exports = (config, navTree) ->
     obj.title = HbHelper.render(title, obj)
     [ obj.ref, obj.ext ] = filenameToRef(file)
     fileByRef[obj.ref] = obj
-    
 
   exports.buildSearchIndex = ->
     console.log('Building search index...')


### PR DESCRIPTION
This change allows you to pass `pathPrefix` as a key in the config
object when building a doxx site, and all absolute URLS (beginning with
a leading /) will be re-written to prepend the prefix.

Change-type: minor
Signed-off-by: Jack Brown <jack@balena.io>